### PR TITLE
Upgrading groovy upgrade from 2.* to 2.4.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     testCompile("com.github.goldin:spock-extensions:0.1.4") {
         exclude module: "spock-core"
     }
-    testCompile("org.codehaus.groovy:groovy-all:2.3.3")
+    testCompile("org.codehaus.groovy:groovy-all:2.4.4")
     testCompile("org.easytesting:fest-assert:1.4")
 }
 


### PR DESCRIPTION
#### Summary of this PR
Upgrade groovy version from 2.3 to 2.4.4
#### Intended effect
[gradle 2.10](https://docs.gradle.org/2.10/release-notes) can be used, and all it features
#### How should this be manually tested?
./gradlew build will use 2.10 plugin and 2.4.4 groovy
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A