### PR TITLE
Updating report generation and serenity.properties resolution for multimodule projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     testCompile("com.github.goldin:spock-extensions:0.1.4") {
         exclude module: "spock-core"
     }
-    testCompile("org.codehaus.groovy:groovy-all:2.3.3")
+    testCompile("org.codehaus.groovy:groovy-all:2.4.4")
     testCompile("org.easytesting:fest-assert:1.4")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ ext {
     bintrayPackage = 'serenity-core'
     projectDescription = 'Serenity Maven Plugin'
 
-    serenityCoreVersion = '1.1.24-rc.1'
+    serenityCoreVersion = '1.1.25-rc.1'
     if (!project.hasProperty("bintrayUsername")) {
         bintrayUsername = 'wakaleo'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ ext {
     bintrayPackage = 'serenity-core'
     projectDescription = 'Serenity Maven Plugin'
 
-    serenityCoreVersion = '1.1.25-rc.1'
+    serenityCoreVersion = '1.1.25-rc.2'
     if (!project.hasProperty("bintrayUsername")) {
         bintrayUsername = 'wakaleo'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ ext {
     bintrayPackage = 'serenity-core'
     projectDescription = 'Serenity Maven Plugin'
 
-    serenityCoreVersion = '1.1.24'
+    serenityCoreVersion = '1.1.24-rc.1'
     if (!project.hasProperty("bintrayUsername")) {
         bintrayUsername = 'wakaleo'
     }

--- a/src/main/java/net/serenitybdd/maven/plugins/MavenProjectHelper.java
+++ b/src/main/java/net/serenitybdd/maven/plugins/MavenProjectHelper.java
@@ -1,5 +1,7 @@
 package net.serenitybdd.maven.plugins;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -11,6 +13,17 @@ public class MavenProjectHelper {
             return project.getGroupId() + "-" + project.getArtifactId();
         } else {
             return "";
+        }
+    }
+
+    /**
+     * If maven will be executed in module or in project without children, that serenity.properties will be loaded from
+     * correct path, but if mvn executed from root project with children, properties will be loaded root project folder,
+     * but should from module folder, and only after that from root folder - this is fix for it.
+     */
+    protected static void propagateBuildDir(MavenSession session){
+        if(StringUtils.isEmpty(System.getProperty("project.build.directory"))) {
+            System.setProperty("project.build.directory", session.getCurrentProject().getBasedir().getAbsolutePath());
         }
     }
 }

--- a/src/main/java/net/serenitybdd/maven/plugins/MavenProjectHelper.java
+++ b/src/main/java/net/serenitybdd/maven/plugins/MavenProjectHelper.java
@@ -23,6 +23,7 @@ public class MavenProjectHelper {
      */
     protected static void propagateBuildDir(MavenSession session){
         if(StringUtils.isEmpty(System.getProperty("project.build.directory"))) {
+
             System.setProperty("project.build.directory", session.getCurrentProject().getBasedir().getAbsolutePath());
         }
     }

--- a/src/main/java/net/serenitybdd/maven/plugins/SerenityAdaptorMojo.java
+++ b/src/main/java/net/serenitybdd/maven/plugins/SerenityAdaptorMojo.java
@@ -21,7 +21,7 @@ public class SerenityAdaptorMojo extends AbstractMojo {
     /**
      * Aggregate reports are generated here
      */
-    @Parameter(property = "import.target", defaultValue = "target/site/serenity", required=true)
+    @Parameter(property = "import.target", defaultValue = "${user.dir}/target/site/serenity", required=true)
     public File outputDirectory;
 
     /**

--- a/src/main/java/net/serenitybdd/maven/plugins/SerenityAggregatorMojo.java
+++ b/src/main/java/net/serenitybdd/maven/plugins/SerenityAggregatorMojo.java
@@ -81,7 +81,7 @@ public class SerenityAggregatorMojo extends AbstractMojo {
     Configuration configuration;
 
     @Parameter(defaultValue = "${session}")
-    private MavenSession session;
+    protected MavenSession session;
 
     /**
      * Serenity project key

--- a/src/main/java/net/serenitybdd/maven/plugins/SerenityCheckMojo.java
+++ b/src/main/java/net/serenitybdd/maven/plugins/SerenityCheckMojo.java
@@ -1,6 +1,10 @@
 package net.serenitybdd.maven.plugins;
 
+import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.reports.ResultChecker;
+import net.thucydides.core.webdriver.Configuration;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -8,6 +12,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * This plugin deletes existing history files for Serenity for this project.
@@ -17,11 +22,27 @@ public class SerenityCheckMojo extends AbstractMojo {
     /**
      * Aggregate reports are generated here
      */
-    @Parameter(property = "outputDirectory", defaultValue = "${project.build.directory}/site/serenity", required=true)
-    public File outputDirectory;
+    @Parameter(property = "serenity.outputDirectory", defaultValue = "", required=true)
+    public String outputDirectoryPath;
+
+    @Parameter(defaultValue = "${session}")
+    private MavenSession session;
 
     protected ResultChecker getResultChecker() {
+
+        MavenProjectHelper.propagateBuildDir(session);
+        File outputDirectory;
+        if(!StringUtils.isEmpty(outputDirectoryPath)){
+            outputDirectory = session.getCurrentProject().getBasedir().toPath().resolve(outputDirectoryPath).toFile();
+        }else{
+            outputDirectory = session.getCurrentProject().getBasedir().
+                    toPath().resolve(getConfiguration().getOutputDirectory().toPath()).toFile();
+        }
         return new ResultChecker(outputDirectory);
+    }
+
+    private Configuration getConfiguration() {
+        return Injectors.getInjector().getProvider(Configuration.class).get();
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/src/test/java/net/serenitybdd/maven/plugins/WhenGeneratingAnAggregateReport.java
+++ b/src/test/java/net/serenitybdd/maven/plugins/WhenGeneratingAnAggregateReport.java
@@ -1,11 +1,13 @@
 package net.serenitybdd.maven.plugins;
 
 import net.thucydides.core.reports.html.HtmlAggregateStoryReporter;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.File;
@@ -34,7 +36,6 @@ public class WhenGeneratingAnAggregateReport {
     @Mock
     MavenProject project;
 
-
     @Before
     public void setupPlugin() {
         MockitoAnnotations.initMocks(this);
@@ -43,6 +44,14 @@ public class WhenGeneratingAnAggregateReport {
         plugin.setOutputDirectory(outputDirectory);
         plugin.setSourceDirectory(sourceDirectory);
         plugin.setReporter(reporter);
+        plugin.session = Mockito.mock(MavenSession.class);
+        MavenProject project=Mockito.mock(MavenProject.class);
+        Mockito.when(project.getBasedir()).thenReturn(new File("."));
+        Mockito.when(plugin.session.getCurrentProject()).thenReturn(project);
+        Mockito.when(outputDirectory.toPath()).thenReturn(new File(".").toPath());
+        Mockito.when(sourceDirectory.toPath()).thenReturn(new File(".").toPath());
+        Mockito.when(outputDirectory.isAbsolute()).thenReturn(true);
+        Mockito.when(sourceDirectory.isAbsolute()).thenReturn(true);
     }
 
     @Test
@@ -86,12 +95,10 @@ public class WhenGeneratingAnAggregateReport {
         verify(outputDirectory,never()).mkdirs();
     }
 
-
     @Test(expected = MojoExecutionException.class)
     public void if_the_report_cant_be_written_the_plugin_execution_should_fail() throws Exception {
         doThrow(new IOException("IO error")).when(reporter).generateReportsForTestResultsFrom(outputDirectory);
 
         plugin.execute();
     }
-
 }


### PR DESCRIPTION
#### Summary of this PR
Update mvn-plugin to fix problems with multimodule projects with mvn. Enabling parallel execution of tests for all modules.
#### Intended effect
One level projects
App
  src

Multimodule projects
App
  child1
    src
  child2
    src

Before this fix mvn if build executed from root dir (App):
1) used serenity.properties from App dir
2) generated incorrect reports

Before this fix mvn if build executed from module dir (child1 or child2):
1) used serenity.properties from child dir
2) generated correct reports

After this fix mvn if build executed from root dir (App):
1) used serenity.properties from child dir (during execution of child)
2) generate reports in child dir

After this fix mvn if build executed from module dir (child1 or child2):
1) used serenity.properties from child dir (during execution of child)
2) generate reports in child dir
#### How should this be manually tested?
some projects with modules can be build, also serenity-bdd/serenity-test-projects can be used for these tests (it can be build with mvn and gradle)
#### Side effects
N/A
#### Documentation
documentation will be provided under serenity-bdd/serenity-documentation/issues/54, https://github.com/serenity-bdd/serenity-documentation/issues/53
#### Relevant tickets
serenity-bdd/serenity-maven-plugin/issues/9, serenity-bdd/serenity-maven-plugin/issues/22
#### Screenshots (if appropriate)
N/A