### PR TITLE
Updating Serenity core to rc.5, junit to 4.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
     bintrayPackage = 'serenity-core'
     projectDescription = 'Serenity Maven Plugin'
 
-    serenityCoreVersion = '1.1.25-rc.3'
+    serenityCoreVersion = '1.1.25-rc.4'
     if (!project.hasProperty("bintrayUsername")) {
         bintrayUsername = 'wakaleo'
     }
@@ -65,10 +65,11 @@ task wrapper(type: Wrapper) {
 configurations.all {
     resolutionStrategy {
         // fail fast on dependency convergence problems
-        //failOnVersionConflict()
-        force  'org.codehaus.plexus:plexus-classworlds:2.5.2'
-        force 'org.codehaus.plexus:plexus-utils:3.0.20'
-        force 'org.slf4j:slf4j-api:1.7.7'
+        failOnVersionConflict()
+        force 'org.codehaus.plexus:plexus-classworlds:2.5.2',
+            'org.codehaus.plexus:plexus-utils:3.0.20',
+            'org.slf4j:slf4j-api:1.7.7',
+            'commons-collections:commons-collections:3.2.2'
     }
 }
 
@@ -84,7 +85,7 @@ dependencies {
     }
 
     testCompile "ch.qos.logback:logback-classic:1.1.2"
-    testCompile "junit:junit:4.11"
+    testCompile "junit:junit:4.12"
     testCompile "org.hamcrest:hamcrest-core:1.3"
     testCompile('org.mockito:mockito-all:1.9.5') {
         exclude group: "org.hamcrest", module:"hamcrest-all"
@@ -267,6 +268,6 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 task copyDeps(type: Copy) {
-    from configurations.runtime
+    from configurations.runtime + configurations.testCompile
     into project.projectDir.path + "/lib"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
     bintrayPackage = 'serenity-core'
     projectDescription = 'Serenity Maven Plugin'
 
-    serenityCoreVersion = '1.1.25-rc.4'
+    serenityCoreVersion = '1.1.25-rc.5'
     if (!project.hasProperty("bintrayUsername")) {
         bintrayUsername = 'wakaleo'
     }


### PR DESCRIPTION
#### Summary of this PR
Updating dependency for using last serenity core
#### Intended effect
Will be used commons-collections:commons-collections:3.2.2 instead of 3.2.1 as in selenium 2.50.1. 
Also junit with version 4.12 will be used. 
#### How should this be manually tested?
N/A
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A